### PR TITLE
XLIFF: display number of strings even if there are errors

### DIFF
--- a/script/webstatus.py
+++ b/script/webstatus.py
@@ -278,7 +278,11 @@ def main():
                         string_missing = string_stats['missing']
                         string_translated = string_stats['translated']
                         string_total = string_stats['total']
-
+                        if string_stats['errors'] != '':
+                            # For XLIFF I might have errors but still display the available stats
+                            error_status = True
+                            complete = False
+                            error_message = 'Error extracting data: %s' % string_stats['errors']
                     # Run stats
                     if (string_missing == 0 and
                         string_fuzzy == 0 and

--- a/script/xliff_stats.py
+++ b/script/xliff_stats.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import argparse
 import json
@@ -14,6 +15,7 @@ def main():
     missing = 0
     identical = 0
     total = 0
+    errors = []
 
     try:
         xmldoc = minidom.parse(args.source_path)
@@ -24,9 +26,10 @@ def main():
 
             # Check if we have at least one source
             if not source:
-                error_message = 'Trans unit %s is missing a <source> element' \
-                                % trans_unit.attributes['id'].value
-                raise ValueError(error_message)
+                error_msg = u'Trans unit “%s” is missing a <source> element' \
+                            % trans_unit.attributes['id'].value
+                errors.append(error_msg)
+                continue
 
             # Check if there are multiple source/target elements
             if len(source) > 1:
@@ -36,26 +39,27 @@ def main():
                     if source_element.parentNode.tagName != 'alt-trans':
                         source_count += 1
                 if source_count > 1:
-                    error_message = 'Trans unit %s has multiple <source> elements' \
-                                    % trans_unit.attributes['id'].value
-                    raise ValueError(error_message)
+                    error_msg = u'Trans unit “%s” has multiple <source> elements' \
+                                % trans_unit.attributes['id'].value
+                    errors.append(error_msg)
             if len(target) > 1:
                 target_count = 0
                 for target_element in target:
                     if target_element.parentNode.tagName != 'alt-trans':
                         target_count += 1
                 if target_count > 1:
-                    error_message = 'Trans unit %s has multiple <target> elements' \
-                                    % trans_unit.attributes['id'].value
-                    raise ValueError(error_message)
+                    error_msg = u'Trans unit “%s” has multiple <target> elements' \
+                                % trans_unit.attributes['id'].value
+                    errors.append(error_msg)
 
             # Compare strings
             try:
                 source_string = source[0].firstChild.data
             except:
-                error_message = 'Trans unit %s has a malformed or empty <source> element' \
-                                % trans_unit.attributes['id'].value
-                raise ValueError(error_message)
+                error_msg = u'Trans unit “%s” has a malformed or empty <source> element' \
+                            % trans_unit.attributes['id'].value
+                errors.append(error_msg)
+                continue
             if target:
                 try:
                     source_string = source[0].firstChild.data
@@ -64,9 +68,10 @@ def main():
                     if source_string == target_string:
                         identical += 1
                 except:
-                    error_message = 'Trans unit %s has a malformed or empty <target> element' \
-                                    % trans_unit.attributes['id'].value
-                    raise ValueError(error_message)
+                    error_msg = u'Trans unit “%s” has a malformed or empty <target> element' \
+                                % trans_unit.attributes['id'].value
+                    errors.append(error_msg)
+                    continue
             else:
                 missing += 1
 
@@ -76,15 +81,16 @@ def main():
             if len(file_elements) > 0:
                 file_element = file_elements[0]
                 if 'target-language' not in file_element.attributes.keys():
-                    error_message = 'File %s is missing target-language attribute' \
-                                    % file_element.attributes['original'].value
-                    raise ValueError(error_message)
+                    error_msg = u'File “%s” is missing target-language attribute' \
+                                % file_element.attributes['original'].value
+                    errors.append(error_msg)
     except Exception as e:
         print e
         sys.exit(1)
 
     total = translated + missing
     json_data = {
+        "errors": ' - '.join(errors),
         "identical": identical,
         "missing": missing,
         "total": total,


### PR DESCRIPTION
Pass the error messages in the JSON results instead of raising
exceptions.